### PR TITLE
Include Stitching and new corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,8 @@ base directory on storage element for crab specific job outputs (CF_CRAB_BASE_DI
 
 This will install the `softwares` in `eos`, but the `data` and `jobs` directories are in `afs`.
 In the next step, the big output files have to be stored in `eos`.
-So, `law.cfg` needs to be set like here.
+So, `law.cfg` needs to be set like here in this repo.
+
+For any computing system, please make sure that this hard-coded (stupid) line is changed to the proper one:
+
+`thisdir` in the config e.g. here: https://github.com/gsaha009/CPinHToTauTau/blob/main/httcp/config/config_run3.py#L33

--- a/httcp/calibration/main.py
+++ b/httcp/calibration/main.py
@@ -4,8 +4,10 @@
 main calibration script
 """
 
+import functools
+
 from columnflow.calibration import Calibrator, calibrator
-from columnflow.calibration.cms.jets import jec, jec_nominal, jer
+from columnflow.calibration.cms.jets import jets, jec, jec_nominal, jer
 from columnflow.production.cms.seeds import deterministic_seeds
 from columnflow.util import maybe_import
 from columnflow.columnar_util import set_ak_column
@@ -16,30 +18,63 @@ from httcp.util import IF_RUN2, IF_RUN3
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
 
+set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
+
 # derive calibrators to add settings
 #jec_full = jec.derive("jec_full", cls_dict={"mc_only": True, "nominal_only": True})
 
 @calibrator(
     uses={
         deterministic_seeds,
+        "Jet.*",
+        "RawPuppiMET.*",
+        "PuppiMET.*",
         #jec_nominal, jec_full, jer,
+        jets,
         tau_energy_scale,
     },
     produces={
         deterministic_seeds,
+        "Jet.pt_no_corr", "Jet.phi_no_corr", "Jet.eta_no_corr", "Jet.mass_no_corr",
+        "PuppiMET.pt_no_corr", "PuppiMET.phi_no_corr",
         #jec_nominal, jec_full, jer,
+        jets,
         tau_energy_scale,
     },
 )
 def main(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     events = self[deterministic_seeds](events, **kwargs)
 
-    #if self.dataset_inst.is_data or not self.global_shift_inst.is_nominal:
-    #    events = self[jec_nominal](events, **kwargs)
-    #else:
-    #    events = self[jec_full](events, **kwargs)
-    #    events = self[jer](events, **kwargs)
+    events = set_ak_column_f32(events, "Jet.pt_no_corr", events.Jet.pt)
+    events = set_ak_column_f32(events, "Jet.phi_no_corr", events.Jet.phi)
+    events = set_ak_column_f32(events, "Jet.eta_no_corr", events.Jet.eta)
+    events = set_ak_column_f32(events, "Jet.mass_no_corr", events.Jet.mass)
+    
+    #PuppiMET variables before applying energy corrections
+    events = set_ak_column_f32(events, "PuppiMET.pt_no_corr", events.PuppiMET.pt)
+    events = set_ak_column_f32(events, "PuppiMET.phi_no_corr", events.PuppiMET.phi)
 
+    """
+    if self.dataset_inst.is_data or not self.global_shift_inst.is_nominal:
+        events = self[jec_nominal](events, **kwargs)
+    else:
+        events = self[jec_full](events, **kwargs)
+        events = self[jer](events, **kwargs)
+    """
+    if self.config_inst.campaign.x.run == 3:
+        events = ak.with_field(events, events.RawPuppiMET, "RawMET")
+        events = ak.with_field(events, events.PuppiMET, "MET")
+        events = ak.without_field(events, "RawPuppiMET")
+        events = ak.without_field(events, "PuppiMET")
+
+    events = self[jets](events, **kwargs)
+
+    if self.config_inst.campaign.x.run == 3:
+        events = ak.with_field(events, events.RawMET, "RawPuppiMET")
+        events = ak.with_field(events, events.MET, "PuppiMET")
+        events = ak.without_field(events, "RawMET")
+        events = ak.without_field(events, "MET")
+   
     if self.dataset_inst.is_mc: 
         ##Apply tau energy scale correction
         events = self[tau_energy_scale](events, **kwargs)

--- a/httcp/categorization/main.py
+++ b/httcp/categorization/main.py
@@ -39,6 +39,21 @@ def cat_tautau(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array,
 
 
 # ---------------------------------------------------------- #
+#                          For nJets                         #
+# ---------------------------------------------------------- #
+@categorizer(uses={"Jet.pt"})
+def cat_0j(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
+    return events, ak.num(events.Jet.pt, axis=1) == 0
+
+@categorizer(uses={"Jet.pt"})
+def cat_1j(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
+    return events, ak.num(events.Jet.pt, axis=1) == 1
+
+@categorizer(uses={"Jet.pt"})
+def cat_2j(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
+    return events, ak.num(events.Jet.pt, axis=1) >= 2
+
+# ---------------------------------------------------------- #
 #                          For PhiCP                         #
 # ---------------------------------------------------------- #
 
@@ -51,6 +66,9 @@ def cat_pi_1(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, a
 @categorizer(uses={"is_rho_1"})
 def cat_rho_1(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
     return events, events.is_rho_1
+@categorizer(uses={"is_pi_1", "is_rho_1"})
+def cat_pi_rho_1(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
+    return events, (events.is_pi_1 | events.is_rho_1)
 # tau -> a1 (DM2)
 @categorizer(uses={"is_a1_1pr_2pi0_1"})
 def cat_a1dm2_1(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
@@ -87,6 +105,13 @@ def cat_a1dm10_2(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Arra
 def cat_a1dm11_2(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
     return events, events.is_a1_3pr_1pi0_2
 
+# IPSig
+@categorizer(uses={"is_ipsig_0to1_1"})
+def cat_ipsig_0to1_1(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
+    return events, events.is_ipsig_0to1_1
+@categorizer(uses={"is_ipsig_0to1_1"})
+def cat_ipsig_1toany_1(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
+    return events, ~events.is_ipsig_0to1_1
 
 
 # ----- >>>> to make less combinatorics for tautau

--- a/httcp/config/analysis_httcp.py
+++ b/httcp/config/analysis_httcp.py
@@ -67,19 +67,19 @@ add_config_run2_2018(
 # ===>>> 2022 PreEE
 from httcp.config.config_run3 import add_config as add_config_run3_2022_preEE
 from cmsdb.campaigns.run3_2022_preEE_nano_cp_tau_v12 import campaign_run3_2022_preEE_nano_cp_tau_v12
-#add_config_run3_2022_preEE(
-#    analysis_httcp,
-#    campaign_run3_2022_preEE_nano_cp_tau_v12.copy(),
-#    config_name=campaign_run3_2022_preEE_nano_cp_tau_v12.name,
-#    config_id=int(f"{campaign_run3_2022_preEE_nano_cp_tau_v12.id}{1}")
-#)
 add_config_run3_2022_preEE(
     analysis_httcp,
     campaign_run3_2022_preEE_nano_cp_tau_v12.copy(),
-    config_name=f"{campaign_run3_2022_preEE_nano_cp_tau_v12.name}_limited",
-    config_id=int(f"{campaign_run3_2022_preEE_nano_cp_tau_v12.id}{2}"),
-    limit_dataset_files=1
+    config_name=campaign_run3_2022_preEE_nano_cp_tau_v12.name,
+    config_id=int(f"{campaign_run3_2022_preEE_nano_cp_tau_v12.id}{1}")
 )
+#add_config_run3_2022_preEE(
+#    analysis_httcp,
+#    campaign_run3_2022_preEE_nano_cp_tau_v12.copy(),
+#    config_name=f"{campaign_run3_2022_preEE_nano_cp_tau_v12.name}_limited",
+#    config_id=int(f"{campaign_run3_2022_preEE_nano_cp_tau_v12.id}{2}"),
+#    limit_dataset_files=1
+#)
 """
 # ===>>> 2022 PostEE
 from httcp.config.config_run3 import add_config as add_config_run3_2022_postEE

--- a/httcp/config/analysis_httcp.py
+++ b/httcp/config/analysis_httcp.py
@@ -66,20 +66,20 @@ add_config_run2_2018(
 
 # ===>>> 2022 PreEE
 from httcp.config.config_run3 import add_config as add_config_run3_2022_preEE
-from cmsdb.campaigns.run3_2022_preEE_nano_cp_tau_v12 import campaign_run3_2022_preEE_nano_cp_tau_v12
+from cmsdb.campaigns.run3_2022_preEE_nano_cp_tau_v14 import campaign_run3_2022_preEE_nano_cp_tau_v14
 add_config_run3_2022_preEE(
     analysis_httcp,
-    campaign_run3_2022_preEE_nano_cp_tau_v12.copy(),
-    config_name=campaign_run3_2022_preEE_nano_cp_tau_v12.name,
-    config_id=int(f"{campaign_run3_2022_preEE_nano_cp_tau_v12.id}{1}")
+    campaign_run3_2022_preEE_nano_cp_tau_v14.copy(),
+    config_name=campaign_run3_2022_preEE_nano_cp_tau_v14.name,
+    config_id=int(f"{campaign_run3_2022_preEE_nano_cp_tau_v14.id}{1}")
 )
-#add_config_run3_2022_preEE(
-#    analysis_httcp,
-#    campaign_run3_2022_preEE_nano_cp_tau_v12.copy(),
-#    config_name=f"{campaign_run3_2022_preEE_nano_cp_tau_v12.name}_limited",
-#    config_id=int(f"{campaign_run3_2022_preEE_nano_cp_tau_v12.id}{2}"),
-#    limit_dataset_files=1
-#)
+add_config_run3_2022_preEE(
+    analysis_httcp,
+    campaign_run3_2022_preEE_nano_cp_tau_v14.copy(),
+    config_name=f"{campaign_run3_2022_preEE_nano_cp_tau_v14.name}_limited",
+    config_id=int(f"{campaign_run3_2022_preEE_nano_cp_tau_v14.id}{2}"),
+    limit_dataset_files=1
+)
 """
 # ===>>> 2022 PostEE
 from httcp.config.config_run3 import add_config as add_config_run3_2022_postEE

--- a/httcp/config/categories.py
+++ b/httcp/config/categories.py
@@ -1,10 +1,9 @@
-
 # coding: utf-8
 
 # To handle many categories:
 # https://github.com/columnflow/columnflow/commit/3a104d633fa47a8efc789f7aba054ed967017347#diff-01da7ecfbc4b8bb83460821147201da604f9825e32cbd51e365bdfcbc7cb0912R61
 # https://github.com/columnflow/columnflow/issues/547
-
+# https://github.com/columnflow/columnflow/issues/559
 
 import law
 import order as od
@@ -13,6 +12,31 @@ from columnflow.config_util import add_category, create_category_combinations
 from httcp.util import call_once_on_config
 
 logger = law.logger.get_logger(__name__)
+
+
+# ############################################################### #
+# To create combinations of categories                            #
+# the entire root -> leaf categories will be in the category_ids  #
+# other combinatorics will be produced in createHistograms task,  #
+# if mentioned                                                    #
+# ############################################################### #
+def create_nested_categories(config: od.Config, categories) -> None:
+
+    def name_fn(categories):
+        catlist = [cat.name for cat in categories.values() if cat]
+        catname = "__".join(catlist)
+        return catname
+    
+    def kwargs_fn(categories):
+        return {
+            "id": sum([c.id for c in categories.values()]),
+            "tags": set.union(*[cat.tags for cat in categories.values() if cat]),
+        }
+
+    n = create_category_combinations(config, categories, name_fn, kwargs_fn)
+    logger.info(f" ---> created {n} categories")
+
+
 
 # ###################### #
 #   for tau-tau channel  #
@@ -35,6 +59,7 @@ def add_hadr_cp_categories(config: od.Config) -> None:
     add_category(config, name="a1dm2_1",       id=5,  selection="cat_a1dm2_1",         label=r"$a_{1}(2p-2\pi^{0})$",                  tags={"tau1a1DM2"      })  # h1 -> a1
     add_category(config, name="a1dm10_1",      id=7,  selection="cat_a1dm10_1",        label=r"$a_{1}(3p-0\pi^{0})$",                  tags={"tau1a1DM10"     })  # h1 -> a1
     add_category(config, name="a1dm11_1",      id=9,  selection="cat_a1dm11_1",        label=r"$a_{1}(3p-1\pi^{0})$",                  tags={"tau1a1DM11"     })  # h1 -> a1
+    add_category(config, name="pi_rho_1",      id=11, selection="cat_pi_rho_1",        label=r"$\pi/\rho$",                            tags={"tau1piorrho"    })  # h1 -> a1
     #add_category(config, name="pi_pi",         id=11, selection="cat_pi_pi",           label=r"$\pi-\pi$",                             tags={"pi","pi"        })  # 
     #add_category(config, name="pi_rho",        id=13, selection="cat_pi_rho",          label=r"$\pi-\rho$",                            tags={"pi","rho"       })  # 
     #add_category(config, name="pi_a1dm2",      id=15, selection="cat_pi_a1dm2",        label=r"$\pi-a_{1}(2p2\pi^{0})$",               tags={"pi","a1DM2"     })  # 
@@ -50,6 +75,89 @@ def add_hadr_cp_categories(config: od.Config) -> None:
     #add_category(config, name="a1dm10_a1dm10", id=35, selection="cat_a1dm10_a1dm10",   label=r"$a_{1}-a_{1}(3p0\pi^{0})$",             tags={"a1DM10","a1DM10"})  # 
     #add_category(config, name="a1dm10_a1dm11", id=37, selection="cat_a1dm10_a1dm11",   label=r"$a_{1}(3p0\pi^{0})-a_{1}(3p1\pi^{0})$", tags={"a1DM10","a1DM11"})  # 
     #add_category(config, name="a1dm11_a1dm11", id=39, selection="cat_a1dm11_a1dm11",   label=r"$a_{1}(3p1\pi^{0})-a_{1}(3p1\pi^{0})$", tags={"a1DM11","a1DM11"})  # 
+
+
+@call_once_on_config()
+def add_tautau_real_categories(config: od.Config) -> None:
+    categories = {
+        "channel": [config.get_category("tautau")],
+        "TorF"   : [config.get_category("real_1")],
+        "abcd"   : [
+            config.get_category("hadA"),  config.get_category("hadB"),
+            config.get_category("hadA0"), config.get_category("hadB0"),
+            config.get_category("hadC0"), config.get_category("hadD0"),
+            config.get_category("hadC"),  config.get_category("hadD"),
+        ],
+        "nj"     : [
+            config.get_category("has_0j"), config.get_category("has_1j"), config.get_category("has_2j"),
+        ],
+        "cp"     : [
+            config.get_category("pi_1"),
+            config.get_category("rho_1"),
+            config.get_category("a1dm2_1"),
+            config.get_category("a1dm10_1"),
+            config.get_category("a1dm11_1"),
+            #config.get_category("pi_pi"),
+            #config.get_category("pi_rho"),
+            #config.get_category("pi_a1dm2"),
+            #config.get_category("pi_a1dm10"),
+            #config.get_category("pi_a1dm11"),
+            #config.get_category("rho_rho"),
+            #config.get_category("rho_a1dm2"),
+            #config.get_category("rho_a1dm10"),
+            #config.get_category("rho_a1dm11"),
+            #config.get_category("a1dm2_a1dm10"),
+            #config.get_category("a1dm2_a1dm11"),
+            #config.get_category("a1dm10_a1dm10"),
+            #config.get_category("a1dm10_a1dm11"),
+            #config.get_category("a1dm11_a1dm11"),
+        ],
+    }
+    logger.info("tautau_real_categories")
+    create_nested_categories(config, categories)
+    
+
+@call_once_on_config()
+def add_tautau_fake_categories(config: od.Config) -> None:
+    categories = {
+        "channel": [config.get_category("tautau")],
+        "TorF"   : [config.get_category("fake_1")],
+        "abcd"   : [
+            config.get_category("hadA"),  config.get_category("hadB"),
+            config.get_category("hadA0"), config.get_category("hadB0"),
+            config.get_category("hadC0"), config.get_category("hadD0"),
+            config.get_category("hadC"),  config.get_category("hadD"),
+        ],
+        "nj"     : [
+            config.get_category("has_0j"), config.get_category("has_1j"), config.get_category("has_2j"),
+        ],
+        "cp"     : [
+            config.get_category("pi_1"),
+            config.get_category("rho_1"),
+            config.get_category("a1dm2_1"),
+            config.get_category("a1dm10_1"),
+            config.get_category("a1dm11_1"),
+            #config.get_category("pi_pi"),
+            #config.get_category("pi_rho"),
+            #config.get_category("pi_a1dm2"),
+            #config.get_category("pi_a1dm10"),
+            #config.get_category("pi_a1dm11"),
+            #config.get_category("rho_rho"),
+            #config.get_category("rho_a1dm2"),
+            #config.get_category("rho_a1dm10"),
+            #config.get_category("rho_a1dm11"),
+            #config.get_category("a1dm2_a1dm10"),
+            #config.get_category("a1dm2_a1dm11"),
+            #config.get_category("a1dm10_a1dm10"),
+            #config.get_category("a1dm10_a1dm11"),
+            #config.get_category("a1dm11_a1dm11"),
+        ],
+    }
+    logger.info("tautau_fake_categories")
+    create_nested_categories(config, categories)
+
+
+
     
 # ###################### #
 #   for lep-tau channel  #
@@ -76,7 +184,106 @@ def add_lept_cp_categories(config: od.Config) -> None:
     
 
 @call_once_on_config()
-def add_etau_mutau_categories(config: od.Config) -> None:
+def add_etau_mutau_real_categories(config: od.Config) -> None:
+    categories = {
+        "channel": [config.get_category("etau"),
+                    config.get_category("mutau")],
+        "TorF"   : [config.get_category("real_2")],
+        "abcd"   : [config.get_category("lepA"),  config.get_category("lepB"),
+                    config.get_category("lepA0"), config.get_category("lepB0"),
+                    config.get_category("lepA1"), config.get_category("lepB1"),
+                    config.get_category("lepC"),  config.get_category("lepD")],
+        "cp"     : [config.get_category("pi_2"),
+                    config.get_category("rho_2"),
+                    config.get_category("a1dm2_2"),
+                    config.get_category("a1dm10_2"),
+                    config.get_category("a1dm11_2")],
+    }
+    logger.info("etau_mutau_real_categories")
+    create_nested_categories(config, categories)
+
+    
+@call_once_on_config()
+def add_etau_mutau_fake_categories(config: od.Config) -> None:
+    categories = {
+        "channel": [config.get_category("etau"),
+                    config.get_category("mutau")],
+        "TorF"   : [config.get_category("fake_2")],
+        "abcd"   : [config.get_category("lepA"),  config.get_category("lepB"),
+                    config.get_category("lepA0"), config.get_category("lepB0"),
+                    config.get_category("lepA1"), config.get_category("lepB1"),
+                    config.get_category("lepC"),  config.get_category("lepD")],
+        "cp"     : [config.get_category("pi_2"),
+                    config.get_category("rho_2"),
+                    config.get_category("a1dm2_2"),
+                    config.get_category("a1dm10_2"),
+                    config.get_category("a1dm11_2")],
+    }
+    logger.info("etau_mutau_fake_categories")
+    create_nested_categories(config, categories)
+    
+
+# ########################### #
+# Add extra common categories #
+# ########################### #
+    
+@call_once_on_config()
+def add_common_categories(config):
+
+    add_category(config,
+                 name="incl",
+                 id=900000,
+                 selection="cat_incl",
+                 label=r"$Inclusive$",
+                 tags={"incl"})
+    add_category(config, name="real_1", id=10000, selection="cat_real_1", label=r"lep1 real", tags={"tau1isRealMC"})
+    add_category(config, name="fake_1", id=20000, selection="cat_fake_1", label=r"lep1 fake", tags={"tau1isFakeMC"})
+    add_category(config, name="real_2", id=30000, selection="cat_real_2", label=r"lep2 real", tags={"tau2isRealMC"})
+    add_category(config, name="fake_2", id=40000, selection="cat_fake_2", label=r"lep2 fake", tags={"tau2isFakeMC"})
+
+    add_category(config, name="has_0j", id=51, selection="cat_0j", label=r"has 0jets",          tags={"has0j"})
+    add_category(config, name="has_1j", id=53, selection="cat_1j", label=r"has 1jets",          tags={"has1j"})
+    add_category(config, name="has_2j", id=55, selection="cat_2j", label=r"has 2 or more jets", tags={"has2j"})
+
+    add_category(config, name="ipsig_0to1_1",   id=57, selection="cat_ipsig_0to1_1",   label=r"0 < IP_significance < 1", tags={"tau1_ipsig_0to1"})
+    add_category(config, name="ipsig_1toany_1", id=59, selection="cat_ipsig_1toany_1", label=r"IP_significance > 1",     tags={"tau1_ipsig_1toany"})
+
+    
+# ################### #
+# test categorization #
+# ################### #
+@call_once_on_config()
+def add_test_categories(config: od.config) -> None:
+
+    categories = {
+        "channel": [config.get_category("tautau")],
+        "TorF"   : [config.get_category("real_1")],
+        "abcd"   : [
+            config.get_category("hadA"),   config.get_category("hadB"),
+            config.get_category("hadA0"),  config.get_category("hadB0"),
+            config.get_category("hadC0"),  config.get_category("hadD0"),
+            config.get_category("hadC"),   config.get_category("hadD"),
+        ],
+        "IP"     : [config.get_category("ipsig_0to1_1"), config.get_category("ipsig_1toany_1")],
+        "cp"     : [config.get_category("pi_rho_1")],
+    }
+
+    logger.info("test_categories")
+    create_nested_categories(config, categories)
+    
+
+    
+# ################### #
+# main categorization #
+# ################### #
+
+@call_once_on_config()    
+def add_categories(config: od.Config) -> None:
+    """
+    Adds all categories to a *config*.
+    """
+    add_common_categories(config)
+
     add_category(config,
                  name="etau",
                  id=100000,
@@ -89,136 +296,21 @@ def add_etau_mutau_categories(config: od.Config) -> None:
                  selection="cat_mutau",
                  label=r"$\mu\tau_{h}$",
                  tags={"mutau"})
-
-    add_leptauh_ABCD_categories(config)
-    add_lept_cp_categories(config)
-
-    categories = {
-        "channel": [config.get_category("etau"),
-                    config.get_category("mutau")],
-        "abcd"   : [config.get_category("lepA"),  config.get_category("lepB"),
-                    config.get_category("lepA0"), config.get_category("lepB0"),
-                    config.get_category("lepA1"), config.get_category("lepB1"),
-                    config.get_category("lepC"),  config.get_category("lepD")],
-        "TorF"   : [config.get_category("real_2"),  config.get_category("fake_2")],
-        #"abcd"   : [config.get_category("lepC"),  config.get_category("lepD")],
-        "cp"     : [config.get_category("pi_2"),
-                    config.get_category("rho_2"),
-                    config.get_category("a1dm2_2"),
-                    config.get_category("a1dm10_2"),
-                    config.get_category("a1dm11_2")],
-    }
-    
-    def name_fn(categories):
-        catlist = [cat.name for cat in categories.values() if cat]
-        catname = "__".join(catlist)
-        return catname
-
-    
-    def kwargs_fn(categories):
-        dictnry = {
-            # just increment the category id
-            # NOTE: for this to be deterministic, the order of the categories must no change!
-            #"id": "+",
-            "id": sum([c.id for c in categories.values()]),
-            # join all tags
-            "tags": set.union(*[cat.tags for cat in categories.values() if cat]),
-            #"aux": {
-            #    # the fake factors group name
-            #    "fakefactors_group": name_fn({name: cat for name, cat in categories.items() if name not in {"sign", "tau2"}}),
-            #},
-        }
-        return dictnry
-    
-    create_category_combinations(config, categories, name_fn, kwargs_fn)
-    
-    
-    
-@call_once_on_config()
-def add_tautau_categories(config: od.Config) -> None:
     add_category(config,
                  name="tautau",
                  id=400000,
                  selection="cat_tautau",
-                 label=r"$\tau_{h}\tau_{h}$",
-                 tags="tautau")
+                 label=r"$\tau_{h} \tau_{h}$",
+                 tags={"tautau"})
 
+    add_leptauh_ABCD_categories(config)
+    add_lept_cp_categories(config)
     add_hadtauh_ABCD_categories(config)
     add_hadr_cp_categories(config)
     
-    categories = {
-        "channel": [config.get_category("tautau")],
-        "abcd"   : [
-            config.get_category("hadA"),  config.get_category("hadB"),
-            config.get_category("hadA0"), config.get_category("hadB0"),
-            config.get_category("hadC0"), config.get_category("hadD0"),
-            config.get_category("hadC"),  config.get_category("hadD"),
-        ],
-        "TorF"   : [config.get_category("real_1"), config.get_category("fake_1")],
-        "cp"     : [
-            config.get_category("pi_1"),
-            config.get_category("rho_1"),
-            config.get_category("a1dm2_1"),
-            config.get_category("a1dm10_1"),
-            config.get_category("a1dm11_1"),
-            #config.get_category("pi_pi"),
-            #config.get_category("pi_rho"),
-            #config.get_category("pi_a1dm2"),
-            #config.get_category("pi_a1dm10"),
-            #config.get_category("pi_a1dm11"),
-            #config.get_category("rho_rho"),
-            #config.get_category("rho_a1dm2"),
-            #config.get_category("rho_a1dm10"),
-            #config.get_category("rho_a1dm11"),
-            #config.get_category("a1dm2_a1dm10"),
-            #config.get_category("a1dm2_a1dm11"),
-            #config.get_category("a1dm10_a1dm10"),
-            #config.get_category("a1dm10_a1dm11"),
-            #config.get_category("a1dm11_a1dm11"),
-        ],
-    }
+    #add_etau_mutau_real_categories(config)
+    #add_etau_mutau_fake_categories(config)
+    add_tautau_real_categories(config)
+    #add_tautau_fake_categories(config)
     
-    def name_fn(categories):
-        catlist = [cat.name for cat in categories.values() if cat]
-        catname = "__".join(catlist)
-        return catname
-    
-    def kwargs_fn(categories):
-        dictnry = {
-            # just increment the category id
-            # NOTE: for this to be deterministic, the order of the categories must no change!
-            #"id": "+",
-            "id": sum([c.id for c in categories.values()]),
-            # join all tags
-            "tags": set.union(*[cat.tags for cat in categories.values() if cat]),
-            # auxiliary information
-            #"aux": {
-            #    # the fake factors group name
-            #    "fakefactors_group": name_fn({name: cat for name, cat in categories.items() if name not in {"sign", "tau2"}}),
-            #},
-        }
-
-        return dictnry
-        
-    create_category_combinations(config, categories, name_fn, kwargs_fn)
-    
-    
-@call_once_on_config()    
-def add_categories(config: od.Config) -> None:
-    """
-    Adds all categories to a *config*.
-    """
-    add_category(config,
-                 name="incl",
-                 id=900000,
-                 selection="cat_incl",
-                 label=r"$Inclusive$",
-                 tags={"incl"})
-
-    add_category(config, name="real_1", id=10000, selection="cat_real_1", label=r"lep1 real", tags={"tau1isRealMC"})
-    add_category(config, name="fake_1", id=20000, selection="cat_fake_1", label=r"lep1 fake", tags={"tau1isFakeMC"})
-    add_category(config, name="real_2", id=30000, selection="cat_real_2", label=r"lep2 real", tags={"tau2isRealMC"})
-    add_category(config, name="fake_2", id=40000, selection="cat_fake_2", label=r"lep2 fake", tags={"tau2isFakeMC"})
-
-    add_etau_mutau_categories(config)
-    add_tautau_categories(config)
+    #add_test_categories(config)

--- a/httcp/config/config_run3.py
+++ b/httcp/config/config_run3.py
@@ -72,17 +72,17 @@ def add_config (ana: od.Analysis,
 
     # add custom processes
     cfg.add_process(
-        name="dy_m50toinf_lep",
+        name="dy_m50toinf_lep", #"dy_leplep",
         id=51099,
         #label=r"$Z \to \ell\ell$",
     )
     cfg.add_process(
-        name="dy_m50toinf_tau",
+        name="dy_m50toinf_tau", #"dy_tautau",
         id=51098,
         #label=r"$Z \to \tau\tau$",
     )
     cfg.add_process(
-        name="dy_m50toinf_mc_fake",
+        name="dy_m50toinf_mc_fake", #"dy_mc_fake",
         id=51097,
         #label=r"$Z \to fake (MC)$",
     )
@@ -93,16 +93,13 @@ def add_config (ana: od.Analysis,
         ## W + jets
         "w_lnu",
         ## Drell-Yan
+        # "dy",
         "dy_m10to50",
         "dy_m50toinf",
-        #"dy_z2ll",
-        #"dy_z2tautau",
         ## TTJets
         "tt",
         ## Single top
         "st",
-        #"st_tchannel",
-        #"st_twchannel",
         ## VV [diboson inclusive]
         "vv",
         ## Signal

--- a/httcp/config/config_run3.py
+++ b/httcp/config/config_run3.py
@@ -69,33 +69,18 @@ def add_config (ana: od.Analysis,
     # --------------------------------------------------------------------------------------------- #
     # add processes we are interested in
     # --------------------------------------------------------------------------------------------- #
-
-    # add custom processes
-    cfg.add_process(
-        name="dy_m50toinf_lep", #"dy_leplep",
-        id=51099,
-        #label=r"$Z \to \ell\ell$",
-    )
-    cfg.add_process(
-        name="dy_m50toinf_tau", #"dy_tautau",
-        id=51098,
-        #label=r"$Z \to \tau\tau$",
-    )
-    cfg.add_process(
-        name="dy_m50toinf_mc_fake", #"dy_mc_fake",
-        id=51097,
-        #label=r"$Z \to fake (MC)$",
-    )
-    
     process_names = [
         ## Data
         "data",
         ## W + jets
         "w_lnu",
         ## Drell-Yan
-        # "dy",
-        "dy_m10to50",
-        "dy_m50toinf",
+        "dy",
+        #"dy_m10to50",
+        #"dy_m50toinf",
+        #"dy_m50toinf_lep",
+        #"dy_m50toinf_tau",
+        #"dy_m50toinf_mc_fake",
         ## TTJets
         "tt",
         ## Single top
@@ -104,6 +89,8 @@ def add_config (ana: od.Analysis,
         "vv",
         ## Signal
         "h_ggf_htt",
+        "zh_htt",
+        "wh_htt",
     ]
 
     for process_name in process_names:
@@ -130,10 +117,48 @@ def add_config (ana: od.Analysis,
 
     dataset_names = [
         ##W+jets
-        "wj_incl_madgraph",
-        #Drell-Yan
-        "dy_lep_m10to50_madgraph",
-        "dy_lep_m50_madgraph",
+        # --- LO --- #
+        #"wj_incl_madgraph",
+        #"wj_1j_madgraph",
+        #"wj_2j_madgraph",
+        #"wj_3j_madgraph",
+        #"wj_4j_madgraph",
+        #"wj_ht40to100_madgraph",
+        #"wj_ht100to400_madgraph",
+        #"wj_ht400to800_madgraph",
+        #"wj_ht800to1500_madgraph",
+        #"wj_ht1500to2500_madgraph",
+        # --- NLO --- #
+        "wj_incl_amcatnlo",
+        "wj_0j_amcatnlo",
+        "wj_1j_amcatnlo",
+        "wj_2j_amcatnlo",
+        ##Drell-Yan
+        # --- LO --- #
+        #"dy_lep_m10to50_madgraph",
+        #"dy_lep_m50_madgraph",
+        #"dy_lep_m50_1j_madgraph",
+        #"dy_lep_m50_2j_madgraph",
+        #"dy_lep_m50_3j_madgraph",
+        #"dy_lep_m50_4j_madgraph",
+        # --- NLO --- #
+        "dy_lep_m10to50_amcatnlo",
+        "dy_lep_m50_amcatnlo",
+        "dy_lep_m50_0j_amcatnlo",
+        "dy_lep_m50_1j_amcatnlo",
+        "dy_lep_m50_2j_amcatnlo",
+        #"dy_lep_m50_1j_pt0to40_amcatnlo",
+        #"dy_lep_m50_2j_pt0to40_amcatnlo",
+        "dy_lep_m50_1j_pt40to100_amcatnlo",
+        "dy_lep_m50_2j_pt40to100_amcatnlo",
+        "dy_lep_m50_1j_pt100to200_amcatnlo",
+        "dy_lep_m50_2j_pt100to200_amcatnlo",
+        "dy_lep_m50_1j_pt200to400_amcatnlo",
+        "dy_lep_m50_2j_pt200to400_amcatnlo",
+        "dy_lep_m50_1j_pt400to600_amcatnlo",
+        "dy_lep_m50_2j_pt400to600_amcatnlo",
+        "dy_lep_m50_1j_pt600toInf_amcatnlo",
+        "dy_lep_m50_2j_pt600toInf_amcatnlo",
         ## ttbar
         "tt_sl",
         "tt_dl",
@@ -151,13 +176,22 @@ def add_config (ana: od.Analysis,
         "ww",
         "wz",
         "zz",
-        ## single top tW channel
-        #"st_t_wminus_to_2l2nu",
-        #"st_tbar_wplus_to_lnu2q",
-        #"st_tbar_wplus_to_2l2nu",
-        "h_ggf_tautau_prod_cp_even_sm",
-        #"h_ggf_tautau_flat",
+        # signal
         "h_ggf_tautau_uncorrelated_filter",
+        "h_ggf_tautau_uncorrelatedDecay_CPodd_Filtered_ProdAndDecay",
+        "h_ggf_tautau_uncorrelatedDecay_CPodd_UnFiltered_ProdAndDecay",
+        "h_ggf_tautau_uncorrelatedDecay_MM_Filtered_ProdAndDecay",
+        "h_ggf_tautau_uncorrelatedDecay_MM_UnFiltered_ProdAndDecay",
+        "h_ggf_tautau_uncorrelatedDecay_SM_Filtered_ProdAndDecay",
+        "h_ggf_tautau_uncorrelatedDecay_SM_UnFiltered_ProdAndDecay",
+        "h_ggf_tautau_M125_amcatnloFXFX",
+        "h_ggf_tautau_prod_cp_even_sm",
+        "zh_tautau_uncorrelatedDecay_Filtered",
+        "zh_tautau_uncorrelatedDecay_UnFiltered",
+        "wph_tautau_uncorrelatedDecay_Filtered",
+        "wph_tautau_uncorrelatedDecay_UnFiltered",
+        "wmh_tautau_uncorrelatedDecay_Filtered",
+        "wmh_tautau_uncorrelatedDecay_UnFiltered",
     ]
     
     datasets_data = []
@@ -205,8 +239,14 @@ def add_config (ana: od.Analysis,
         dataset = cfg.add_dataset(campaign.get_dataset(dataset_name))
         if re.match(r"^(ww|wz|zz)$", dataset.name):
             dataset.add_tag("no_lhe_weights")
-        if re.match(r"^dy_lep_m50_madgraph$", dataset.name):
-            dataset.add_tag("is_dy_LO")
+        elif re.match(r"^dy_lep_m50.*$", dataset.name):
+            dataset.add_tag("is_dy")
+        elif re.match(r"^wj.*$", dataset.name):
+            dataset.add_tag("is_w")
+        elif re.match(r"^h_ggf_tautau.*$", dataset.name):
+            dataset.add_tag("is_ggf_signal")
+        elif re.match(r"^(.*)h_tautau(.*)Filtered$", dataset.name):
+            dataset.add_tag("is_vh_signal")
         
         # for testing purposes, limit the number of files to 1
         for info in dataset.info.values():
@@ -237,7 +277,7 @@ def add_config (ana: od.Analysis,
         "backgrounds": (backgrounds := [
             "w_lnu",
             "tt",
-            "dy_m50toinf",
+            "dy_m50toinf", "dy_m10to50",
             "st",
             "vv",
         ]),
@@ -246,7 +286,7 @@ def add_config (ana: od.Analysis,
         "data_bkg_sig"  : (data_bkg_sig  := [*backgrounds, "data", "h_ggf_tautau"]),
     }
     cfg.x.process_settings_groups = {
-        "unstack_processes": {proc: {"unstack": True, "scale": 10.0} for proc in ("h_ggf_tautau")},
+        "unstack_processes": {proc: {"unstack": True, "scale": 10.0} for proc in ("h_ggf_htt")},
     }
     cfg.x.general_settings_groups = {
         "compare_shapes": {"skip_ratio": False, "shape_norm": False, "yscale": "log"} #"cms_label": "simpw"},
@@ -288,6 +328,40 @@ def add_config (ana: od.Analysis,
     # (currently set to false because the number of files per dataset is truncated to 2)
     cfg.x.validate_dataset_lfns = False
 
+    # define inclusive datasets for the stitched process identification with corresponding leaf processes
+    # drell-yan [NLO]
+    cfg.x.allow_dy_stitching = True
+    cfg.x.dy_stitching = {
+        "dy": {
+            "inclusive_dataset": cfg.datasets.n.dy_lep_m50_amcatnlo,
+            "leaf_processes": [
+                # the following processes cover the full njet and pt phasespace
+                procs.n.dy_m50toinf_0j,
+                *(
+                    procs.get(f"dy_m50toinf_{nj}j_pt{pt}")
+                    for nj in [1, 2]
+                    for pt in ["0to40", "40to100", "100to200", "200to400", "400to600", "600toinf"]
+                ),
+                #procs.n.dy_m50toinf_ge3j,
+            ],
+        },
+    }
+    # w+jets [NLO]
+    cfg.x.allow_w_stitching = True
+    cfg.x.w_stitching = {
+        "wj": {
+            "inclusive_dataset": cfg.datasets.n.wj_incl_amcatnlo,
+            "leaf_processes": [
+                # the following processes cover the full njet and pt phasespace
+                *(
+                    procs.get(f"w_lnu_{nj}j") # njet from NLO samples
+                    for nj in [0,1,2]
+                ),
+            ],
+        },
+    }
+    
+    
     # --------------------------------------------------------------------------------------------- #
     # Luminosity and Normalization
     # lumi values in inverse fb
@@ -553,11 +627,11 @@ def add_config (ana: od.Analysis,
             # "FlavorPureQuark",
             # "FlavorPureCharm",
             # "FlavorPureBottom",
-            "CorrelationGroupMPFInSitu",
-            "CorrelationGroupIntercalibration",
-            "CorrelationGroupbJES",
-            "CorrelationGroupFlavor",
-            "CorrelationGroupUncorrelated",
+            #"CorrelationGroupMPFInSitu",
+            #"CorrelationGroupIntercalibration",
+            #"CorrelationGroupbJES",
+            #"CorrelationGroupFlavor",
+            #"CorrelationGroupUncorrelated",
         ],
     })
 
@@ -878,10 +952,15 @@ def add_config (ana: od.Analysis,
             dataset.x.event_weights = {
                 "pdf_weight": [], #get_shifts("pdf"),
             }
-        if dataset.x("is_dy_LO", True):
+        if dataset.x("is_dy", False):
             dataset.x.event_weights = {
                 "zpt_reweight": [],
             }
+        if dataset.x("is_ggf_signal", False) or dataset.x("is_vh_signal", False):
+            dataset.x.event_weights = {
+                "tauspinner_weight" : get_shifts("tauspinner"),
+            }
+            
     #cfg.x.default_weight_producer = "all_weights"
 
     
@@ -995,6 +1074,8 @@ def add_config (ana: od.Analysis,
             "is_a1_1pr_2pi0_1", "is_a1_1pr_2pi0_2",
             "is_a1_3pr_0pi0_1", "is_a1_3pr_0pi0_2",
             "is_a1_3pr_1pi0_1", "is_a1_3pr_1pi0_2",
+            "is_ipsig_0to1_1",
+            "LHE.NpNLO", "LHE.Vpt",
         } | {
             f"GenPart.{var}" for var in [
                 "pt", "eta", "phi", "mass",
@@ -1006,6 +1087,7 @@ def add_config (ana: od.Analysis,
             ]
         } | {
             f"PuppiMET.{var}" for var in [
+                "pt_no_corr", "phi_no_corr",
                 "pt", "phi", "significance",
                 "covXX", "covXY", "covYY",
             ]
@@ -1016,6 +1098,8 @@ def add_config (ana: od.Analysis,
             ]
         } | {
             f"Jet.{var}" for var in [
+                "pt_no_corr", "eta_no_corr",
+                "phi_no_corr", "mass_no_corr",
                 "pt", "eta", "phi", "mass",
                 "btagDeepFlavB", "hadronFlavour"
             ]

--- a/httcp/config/config_run3.py
+++ b/httcp/config/config_run3.py
@@ -69,6 +69,23 @@ def add_config (ana: od.Analysis,
     # --------------------------------------------------------------------------------------------- #
     # add processes we are interested in
     # --------------------------------------------------------------------------------------------- #
+
+    # add custom processes
+    cfg.add_process(
+        name="dy_m50toinf_lep",
+        id=51099,
+        #label=r"$Z \to \ell\ell$",
+    )
+    cfg.add_process(
+        name="dy_m50toinf_tau",
+        id=51098,
+        #label=r"$Z \to \tau\tau$",
+    )
+    cfg.add_process(
+        name="dy_m50toinf_mc_fake",
+        id=51097,
+        #label=r"$Z \to fake (MC)$",
+    )
     
     process_names = [
         ## Data
@@ -101,6 +118,7 @@ def add_config (ana: od.Analysis,
         #if process_name == "h_ggf_tautau":
         #    procs.get(process_name).is_signal = True
         proc = cfg.add_process(procs.get(process_name))
+        #print(procs.get(process_name))
         #if proc.name == "h_ggf_tautau":
         #    proc.is_signal = True
 

--- a/httcp/config/styles.py
+++ b/httcp/config/styles.py
@@ -17,6 +17,16 @@ def stylize_processes(config: od.Config) -> None:
 
     # recommended cms colors
     cfg.x.colors = DotDict(
+        col_h_ggf_htt="#690301",
+        col_tt="#998ec3",
+        col_st="#5ab4ac",
+        col_vv="#5a3a1a",
+        col_w="#d78a7e",
+        col_dy="#fec44f",
+        col_dy_lep="#3690c0",
+        col_dy_tau="#fec44f",
+        col_dy_lm="#357591",
+        col_h="#f768a1",
         light_blue="#bbd3f3",
         bright_blue="#0aa4f6",
         dark_blue="#10376c",
@@ -37,52 +47,62 @@ def stylize_processes(config: od.Config) -> None:
     )
 
     if (p := config.get_process("h_ggf_htt", default=None)):
-        p.color1 = cfg.x.colors.black
-        p.label = (
-            r"$H_{ggf} \rightarrow \tau\tau$"
-        )
+        p.color1 = cfg.x.colors.col_h_ggf_htt
+        p.label = r"$H_{ggf} \rightarrow \tau\tau$"
         
     if (p := config.get_process("h", default=None)):
-        p.color1 = cfg.x.colors.purple
+        p.color1 = cfg.x.colors.col_h
+        p.label = r"$Higgs$"
 
     if (p := config.get_process("tt", default=None)):
-        p.color1 = cfg.x.colors.light_purple
+        p.color1 = cfg.x.colors.col_tt
         p.label = r"$t\bar{t}$"
 
     if (p := config.get_process("st", default=None)):
-        p.color1 = cfg.x.colors.aubergine
-
+        p.color1 = cfg.x.colors.col_st
+        p.label = r"$Single ~t(W)$"
+        
     #if (p := config.get_process("dy", default=None)):
     #    p.color1 = cfg.x.colors.brown
-    if (p := config.get_process("dy_m50toinf", default=None)):
-        p.color1 = cfg.x.colors.brown
-        p.label = r"$Z\to \ell \ell (e/\mu/\tau)$"
-    if (p := config.get_process("dy_m50toinf_lep", default=None)):
-        p.color1 = cfg.x.colors.light_blue
-        p.label = r"$Z\to \ell \ell ~(ee/\mu\mu)$"
-    if (p := config.get_process("dy_m50toinf_tau", default=None)):
-        p.color1 = cfg.x.colors.dark_blue
-        p.label = r"$Z\to \tau \tau$"
+    if (p := config.get_process("dy", default=None)):
+        p.color1 = cfg.x.colors.col_dy
+        p.label = r"$Z\to \ell^+ \ell^- (\ell \equiv e/\mu/\tau)$"
 
-    if (p := config.get_process("dy_lep_m10to50", default=None)):
-        p.color1 = cfg.x.colors.grey
-        p.label = r"$Z\to \ell \ell (M < 50)$"
+    if (p := config.get_process("dy_m50toinf", default=None)):
+        p.color1 = cfg.x.colors.col_dy
+        p.label = r"$Z\to \ell^+ \ell^- (\ell \equiv e/\mu/\tau)$"
+        
+    if (p := config.get_process("dy_m50toinf_lep", default=None)):
+        p.color1 = cfg.x.colors.col_dy_lep
+        p.label = r"$Z \to \ell^+ \ell^- (\ell \equiv e/\mu)$"
+        
+    if (p := config.get_process("dy_m50toinf_tau", default=None)):
+        p.color1 = cfg.x.colors.col_dy_tau
+        p.label = r"$Z \to \ell^+ \ell^- (\ell \equiv \tau)$"
+
+    #if (p := config.get_process("dy_m50toinf_mc_fake", default=None)):
+    #    p.color1 = cfg.x.colors.col_dy_mcfake
+    #    p.label = r"$Z\to j(\tau_{h}) \tau_{h}$"
+        
+    if (p := config.get_process("dy_m10to50", default=None)):
+        p.color1 = cfg.x.colors.col_dy_lm
+        p.label = r"$Z\to \ell^+ \ell^- (m < 50)$"
 
     if (p := config.get_process("vv", default=None)):
-        p.color1 = cfg.x.colors.yellow
+        p.color1 = cfg.x.colors.col_vv
 
     if (p := config.get_process("vvv", default=None)):
-        p.color1 = cfg.x.colors.yellow
+        p.color1 = cfg.x.colors.col_vv
 
     if (p := config.get_process("multiboson", default=None)):
         p.color1 = cfg.x.colors.yellow
 
     if (p := config.get_process("w", default=None)):
-        p.color1 = cfg.x.colors.bright_orange
-        p.label = "W"
+        p.color1 = cfg.x.colors.col_w
+        p.label = "W + jets"
     if (p := config.get_process("w_lnu", default=None)):
-        p.color1 = cfg.x.colors.bright_orange
-        p.label = "W"
+        p.color1 = cfg.x.colors.col_w
+        p.label = "W + jets"
 
     if (p := config.get_process("ewk", default=None)):
         p.color1 = cfg.x.colors.brown

--- a/httcp/config/styles.py
+++ b/httcp/config/styles.py
@@ -36,7 +36,7 @@ def stylize_processes(config: od.Config) -> None:
         black="#000000",
     )
 
-    if (p := config.get_process("h_ggf_tautau", default=None)):
+    if (p := config.get_process("h_ggf_htt", default=None)):
         p.color1 = cfg.x.colors.black
         p.label = (
             r"$H_{ggf} \rightarrow \tau\tau$"
@@ -54,13 +54,13 @@ def stylize_processes(config: od.Config) -> None:
 
     #if (p := config.get_process("dy", default=None)):
     #    p.color1 = cfg.x.colors.brown
-    if (p := config.get_process("dy_lep_m50", default=None)):
+    if (p := config.get_process("dy_m50toinf", default=None)):
         p.color1 = cfg.x.colors.brown
         p.label = r"$Z\to \ell \ell (e/\mu/\tau)$"
-    if (p := config.get_process("dy_z2ll", default=None)):
+    if (p := config.get_process("dy_m50toinf_lep", default=None)):
         p.color1 = cfg.x.colors.light_blue
         p.label = r"$Z\to \ell \ell ~(ee/\mu\mu)$"
-    if (p := config.get_process("dy_z2tautau", default=None)):
+    if (p := config.get_process("dy_m50toinf_tau", default=None)):
         p.color1 = cfg.x.colors.dark_blue
         p.label = r"$Z\to \tau \tau$"
 

--- a/httcp/config/variables.py
+++ b/httcp/config/variables.py
@@ -301,6 +301,13 @@ def add_hcand_features(cfg: od.Config) -> None:
             binning=(40, 0.0, 10),
             x_title=f"hcand[{i+1}]" + r" $IP Significance$",
         )
+        cfg.add_variable(
+            name=f"dphi_met_h{i+1}",
+            expression=f"dphi_met_h{i+1}",
+            null_value=EMPTY_FLOAT,
+            binning=(32, -np.pi, np.pi),
+            x_title=f"hcand[{i+1}]" + r" $-MET \Delta_{phi}$",
+        )
 
     cfg.add_variable(
         name="hcand_invm",
@@ -317,6 +324,13 @@ def add_hcand_features(cfg: od.Config) -> None:
         binning=(40, 0, 5),
         x_title=r"$\Delta R(h1,h2)$",
     )
+    cfg.add_variable(
+        name="hcand_met_var_qcd",
+        expression="met_var_qcd_h1",
+        null_value=EMPTY_FLOAT,
+        binning=(20, -5.0, 5.0),
+        x_title=r"$MET QCD var$$",
+    )    
     # PhiCP - Det
     cfg.add_variable(
         name="PhiCP_IPIP",

--- a/httcp/production/main.py
+++ b/httcp/production/main.py
@@ -10,6 +10,7 @@ from typing import Optional
 from columnflow.production import Producer, producer
 from columnflow.production.categories import category_ids
 from columnflow.production.normalization import normalization_weights
+from columnflow.production.normalization import stitched_normalization_weights
 
 from columnflow.production.cms.pileup import pu_weight
 from columnflow.production.cms.pdf import pdf_weights
@@ -26,7 +27,6 @@ from columnflow.columnar_util import optional_column as optional
 from httcp.production.ReArrangeHcandProds import reArrangeDecayProducts, reArrangeGenDecayProducts
 from httcp.production.PhiCP_Producer import ProduceDetPhiCP, ProduceGenPhiCP
 #from httcp.production.weights import tauspinner_weight
-#from IPython import embed
 from httcp.production.extra_weights import zpt_reweight, ff_weight # ff_weight : dummy
 from httcp.production.muon_weights import muon_id_weights, muon_iso_weights, muon_trigger_weights, muon_xtrigger_weights
 from httcp.production.electron_weights import electron_idiso_weights, electron_trigger_weights, electron_xtrigger_weights
@@ -40,7 +40,8 @@ from httcp.production.sample_split import split_dy
 
 #from httcp.production.angular_features import ProduceDetCosPsi, ProduceGenCosPsi
 
-from httcp.util import IF_DATASET_HAS_LHE_WEIGHTS, IF_DATASET_IS_DY_LO
+from httcp.util import IF_DATASET_HAS_LHE_WEIGHTS, IF_DATASET_IS_DY, IF_DATASET_IS_W, IF_DATASET_IS_SIGNAL
+from httcp.util import IF_RUN2, IF_RUN3, IF_ALLOW_STITCHING
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -58,6 +59,7 @@ logger = law.logger.get_logger(__name__)
         # nano columns
         "hcand.*", optional("GenTau.*"), optional("GenTauProd.*"),
         "Jet.pt",
+        "PuppiMET.pt", "PuppiMET.phi",
         #reArrangeDecayProducts,
         #reArrangeGenDecayProducts,
         #ProduceGenPhiCP, #ProduceGenCosPsi, 
@@ -70,6 +72,7 @@ logger = law.logger.get_logger(__name__)
         "n_jet",
         #ProduceGenPhiCP, #ProduceGenCosPsi,
         #ProduceDetPhiCP, #ProduceDetCosPsi,
+        "dphi_met_h1", "dphi_met_h2", "met_var_qcd_h1",
     },
 )
 def hcand_features(
@@ -81,15 +84,28 @@ def hcand_features(
     hcand_ = ak.with_name(events.hcand, "PtEtaPhiMLorentzVector")
     hcand1 = hcand_[:,0:1]
     hcand2 = hcand_[:,1:2]
+
+    met = ak.with_name(events.PuppiMET, "PtEtaPhiMLorentzVector")
+
     
     mass = (hcand1 + hcand2).mass
-    dr = ak.firsts(hcand1.metric_table(hcand2), axis=1)
-    dr = ak.enforce_type(dr, "var * float32")
+    #dr = ak.firsts(hcand1.metric_table(hcand2), axis=1)
+    #dr = ak.enforce_type(dr, "var * float32")
+    dr = hcand1.delta_r(hcand2)
 
-    events = set_ak_column(events, "hcand_invm", mass)
-    events = set_ak_column(events, "hcand_dr",   dr)
-
+    # deltaPhi between MET and hcand1 & 2
+    dphi_met_h1 = met.delta_phi(hcand1)
+    dphi_met_h2 = met.delta_phi(hcand2)
+    met_var_qcd_h1 = met.pt * np.cos(dphi_met_h1)/hcand1.pt
+    
+    events = set_ak_column_f32(events, "hcand_invm",  mass)
+    events = set_ak_column_f32(events, "hcand_dr",    dr)
+    events = set_ak_column_f32(events, "dphi_met_h1", dphi_met_h1)
+    events = set_ak_column_f32(events, "dphi_met_h2", dphi_met_h2)
+    events = set_ak_column_f32(events, "met_var_qcd_h1", met_var_qcd_h1)
+    
     events = set_ak_column_i32(events, "n_jet", ak.num(events.Jet.pt, axis=1))
+
     
     """
     events, P4_dict     = self[reArrangeDecayProducts](events)
@@ -111,7 +127,8 @@ def hcand_features(
     uses={
         ##deterministic_seeds,
         normalization_weights,
-        split_dy,
+        IF_ALLOW_STITCHING(stitched_normalization_weights),
+        #split_dy,
         pu_weight,
         IF_DATASET_HAS_LHE_WEIGHTS(pdf_weights),
         # -- muon -- #
@@ -125,8 +142,8 @@ def hcand_features(
         electron_xtrigger_weights,
         # -- tau -- #
         tau_weights,
-        #tauspinner_weights,
-        IF_DATASET_IS_DY_LO(zpt_reweight),
+        IF_DATASET_IS_SIGNAL(tauspinner_weights),
+        IF_DATASET_IS_DY(zpt_reweight),
         hcand_features,
         hcand_mass,
         category_ids,
@@ -135,7 +152,8 @@ def hcand_features(
     produces={
         ##deterministic_seeds,
         normalization_weights,
-        split_dy,
+        IF_ALLOW_STITCHING(stitched_normalization_weights),
+        #split_dy,
         pu_weight,
         IF_DATASET_HAS_LHE_WEIGHTS(pdf_weights),
         # -- muon -- #
@@ -149,8 +167,8 @@ def hcand_features(
         electron_xtrigger_weights,
         # -- tau -- #
         tau_weights,
-        #tauspinner_weights,
-        IF_DATASET_IS_DY_LO(zpt_reweight),
+        IF_DATASET_IS_SIGNAL(tauspinner_weights),
+        IF_DATASET_IS_DY(zpt_reweight),
         hcand_features,
         hcand_mass,
         "channel_id",
@@ -167,7 +185,14 @@ def main(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 
     #events = self[ff_weight](events, **kwargs)
     if self.dataset_inst.is_mc:
-        events = self[normalization_weights](events, **kwargs)
+        # allow stitching is applicable only when datasets are DY or wjets, only if the stitching booleans are true in config
+        allow_stitching = bool(ak.any([(self.dataset_inst.has_tag("is_dy") and self.config_inst.x.allow_dy_stitching),
+                                       (self.dataset_inst.has_tag("is_w") and self.config_inst.x.allow_w_stitching)]))
+        if allow_stitching:
+            events = self[stitched_normalization_weights](events, **kwargs)
+        else:
+            events = self[normalization_weights](events, **kwargs)
+
         events = self[pu_weight](events, **kwargs)
         #if not self.dataset_inst.has_tag("no_lhe_weights"):
         if self.has_dep(pdf_weights):
@@ -183,15 +208,18 @@ def main(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         events = self[electron_xtrigger_weights](events, **kwargs)
         # ----------- Tau weights ----------- #        
         events = self[tau_weights](events, do_syst=True, **kwargs)
-        #events = self[tauspinner_weights](events, **kwargs)
-        #if self.dataset_inst.has_tag("is_dy_LO"):
+
+        #from IPython import embed; embed()
+        if self.has_dep(tauspinner_weights):
+            events = self[tauspinner_weights](events, **kwargs)
+
         if self.has_dep(zpt_reweight):
             events = self[zpt_reweight](events, **kwargs)
 
-        processes = self.dataset_inst.processes.names()
-        if ak.any(['dy_' in proc for proc in processes]):
-            logger.info("splitting (any) Drell-Yan dataset ... ")
-            events = self[split_dy](events,**kwargs)
+        #processes = self.dataset_inst.processes.names()
+        #if ak.any(['dy_' in proc for proc in processes]):
+        #    logger.info("splitting (any) Drell-Yan dataset ... ")
+        #    events = self[split_dy](events,**kwargs)
             
     events = self[hcand_features](events, **kwargs)       
 

--- a/httcp/production/main.py
+++ b/httcp/production/main.py
@@ -5,6 +5,7 @@ Column production methods related to higher-level features.
 """
 import functools
 
+import law
 from typing import Optional
 from columnflow.production import Producer, producer
 from columnflow.production.categories import category_ids
@@ -50,6 +51,7 @@ maybe_import("coffea.nanoevents.methods.nanoaod")
 set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
 set_ak_column_i32 = functools.partial(set_ak_column, value_type=np.int32)
 
+logger = law.logger.get_logger(__name__)
 
 @producer(
     uses={
@@ -186,11 +188,10 @@ def main(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         if self.has_dep(zpt_reweight):
             events = self[zpt_reweight](events, **kwargs)
 
-        #processes = self.dataset_inst.processes.names()
-
-        #if ak.any(['dy_' in proc for proc in processes]):
-        #    print("Splitting Drell-Yan dataset...")
-        #    events = self[split_dy](events,**kwargs)
+        processes = self.dataset_inst.processes.names()
+        if ak.any(['dy_' in proc for proc in processes]):
+            logger.info("splitting (any) Drell-Yan dataset ... ")
+            events = self[split_dy](events,**kwargs)
             
     events = self[hcand_features](events, **kwargs)       
 

--- a/httcp/production/processes.py
+++ b/httcp/production/processes.py
@@ -1,0 +1,271 @@
+# coding: utf-8
+
+"""
+Process ID producer relevant for the stitching of the DY samples.
+"""
+
+import functools
+
+import law
+
+from columnflow.production import Producer, producer
+from columnflow.util import maybe_import, InsertableDict
+from columnflow.columnar_util import set_ak_column
+
+from httcp.util import IF_DATASET_IS_DY,IF_DATASET_IS_W
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+sp = maybe_import("scipy")
+maybe_import("scipy.sparse")
+
+
+logger = law.logger.get_logger(__name__)
+
+NJetsRange = tuple[int, int]
+PtRange = tuple[float, float]
+
+set_ak_column_i64 = functools.partial(set_ak_column, value_type=np.int64)
+
+
+# ################################## #
+#      Stitching DYJets samples      #
+# ################################## #
+@producer(
+    uses={
+        IF_DATASET_IS_DY("LHE.NpNLO", "LHE.Vpt"),
+    },
+    produces={
+        IF_DATASET_IS_DY("process_id"),
+    },
+)
+def process_ids_dy(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    """
+    Assigns each dy event a single process id, based on the number of jets and the di-lepton pt of
+    the LHE record. This is used for the stitching of the DY samples.
+    """
+    # as always, we assume that each dataset has exactly one process associated to it
+    #logger.warning(f"dataste : {self.dataset_inst}")
+    if len(self.dataset_inst.processes) != 1:
+        raise NotImplementedError(
+            f"dataset {self.dataset_inst.name} has {len(self.dataset_inst.processes)} processes "
+            "assigned, which is not yet implemented",
+        )
+    process_inst = self.dataset_inst.processes.get_first()
+
+    #from IPython import embed; embed()
+    # get the number of nlo jets and the di-lepton pt
+    njets = events.LHE.NpNLO
+    pt = events.LHE.Vpt
+
+    # raise a warning if a datasets was already created for a specific "bin" (leaf process),
+    # but actually does not fit
+    njets_range = process_inst.x("njets", None)
+    if njets_range is not None:
+        outliers = (njets < njets_range[0]) | (njets >= njets_range[1])
+        if ak.any(outliers):
+            logger.warning(
+                f"dataset {self.dataset_inst.name} is meant to contain njet values in the range "
+                f"[{njets_range[0]}, {njets_range[0]}), but found {ak.sum(outliers)} events "
+                "outside this range",
+            )
+    pt_range = process_inst.x("ptll", None)
+    if pt_range is not None:
+        outliers = (pt < pt_range[0]) | (pt >= pt_range[1])
+        if ak.any(outliers):
+            logger.warning(
+                f"dataset {self.dataset_inst.name} is meant to contain ptll values in the range "
+                f"[{pt_range[0]}, {pt_range[1]}), but found {ak.sum(outliers)} events outside this "
+                "range",
+            )
+
+    #logger.info(f"njets : {njets}, pt : {pt}")
+    #from IPython import embed; embed()
+    # lookup the id and check for invalid values
+    process_ids = np.squeeze(np.asarray(self.id_table[self.key_func(njets, pt)].todense()))
+    #logger.warning(f"Process ids: {process_ids}")
+    #process_ids = ak.where((njets > 0) & (pt < 40.0), process_inst.id, process_ids)
+    #from IPython import embed; embed()
+    invalid_mask = process_ids == 0
+    if ak.any(invalid_mask):
+        raise ValueError(
+            f"found {sum(invalid_mask)} dy events that could not be assigned to a process",
+        )
+
+    # store them
+    events = set_ak_column_i64(events, "process_id", process_ids)
+
+    return events
+
+
+@process_ids_dy.setup
+def process_ids_dy_setup(
+    self: Producer,
+    reqs: dict,
+    inputs: dict,
+    reader_targets: InsertableDict,
+) -> None:
+    # define stitching ranges for the DY datasets covered by this producer's dy_inclusive_dataset
+    stitching_ranges: dict[NJetsRange, list[PtRange]] = {}
+    for proc in self.dy_leaf_processes:
+        njets = proc.x.njets
+        stitching_ranges.setdefault(njets, [])
+        if proc.has_aux("ptll"):
+            stitching_ranges[njets].append(proc.x.ptll)
+
+    # sort by the first element of the ptll range
+    sorted_stitching_ranges: list[tuple[NJetsRange, list[PtRange]]] = [
+        (nj_range, sorted(stitching_ranges[nj_range], key=lambda ptll_range: ptll_range[0]))
+        for nj_range in sorted(stitching_ranges.keys(), key=lambda nj_range: nj_range[0])
+    ]
+
+    # define a key function that maps njets and pt to a unique key for use in a lookup table
+    def key_func(njets, pt):
+        # potentially convert single values into arrays
+        single = False
+        if isinstance(njets, int):
+            assert isinstance(pt, (int, float))
+            njets = np.array([njets], dtype=np.int32)
+            pt = np.array([pt], dtype=np.float32)
+            single = True
+
+        # map into bins (index 0 means no binning)
+        nj_bins = np.zeros(len(njets), dtype=np.int32)
+        pt_bins = np.zeros(len(pt), dtype=np.int32)
+
+        #from IPython import embed; embed()
+        #logger.warning(f"sorted_stitching_ranges : {sorted_stitching_ranges}")
+        for nj_bin, (nj_range, pt_ranges) in enumerate(sorted_stitching_ranges, 1):
+            # nj_bin
+            #logger.info(f"nj_bin : {nj_bin}")
+            #logger.warning(f"nj_range : {nj_range}, pt_ranges : {pt_ranges}")
+            nj_mask = (nj_range[0] <= njets) & (njets < nj_range[1])
+            nj_bins[nj_mask] = nj_bin
+            # pt_bin
+            for pt_bin, (pt_min, pt_max) in enumerate(pt_ranges, 1):
+                pt_mask = (pt_min <= pt) & (pt < pt_max)
+                pt_bins[nj_mask & pt_mask] = pt_bin
+
+        #from IPython import embed; embed()        
+        return (nj_bins[0], pt_bins[0]) if single else (nj_bins, pt_bins)
+
+    self.key_func = key_func
+
+    # define the lookup table
+    max_nj_bin = len(sorted_stitching_ranges)
+    max_pt_bin = max(map(len, stitching_ranges.values()))
+    self.id_table = sp.sparse.lil_matrix((max_nj_bin + 1, max_pt_bin + 1), dtype=np.int64)
+
+    # fill it
+    for proc in self.dy_leaf_processes:
+        key = key_func(proc.x.njets[0], proc.x("ptll", [-1])[0])
+        self.id_table[key] = proc.id
+    # adjustments for missing DY-0to40GeV pt binned process
+    #self.id_table[(2,0)] = 51111 #self.dataset_inst.processes.get_first().id
+    #self.id_table[(3,0)] = 51112 #self.dataset_inst.processes.get_first().id + 1
+    #logger.info(f"id_table : \n{self.id_table}")
+    
+        
+
+
+# ################################## #
+#      Stitching WJets samples       #
+# ################################## #
+@producer(
+    uses={
+        IF_DATASET_IS_W("LHE.NpNLO"),
+    },
+    produces={
+        IF_DATASET_IS_W("process_id"),
+    },
+)
+def process_ids_w(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    """
+    Assigns each dy event a single process id, based on the number of jets and the di-lepton pt of
+    the LHE record. This is used for the stitching of the DY samples.
+    """
+    # as always, we assume that each dataset has exactly one process associated to it
+    if len(self.dataset_inst.processes) != 1:
+        raise NotImplementedError(
+            f"dataset {self.dataset_inst.name} has {len(self.dataset_inst.processes)} processes "
+            "assigned, which is not yet implemented",
+        )
+    process_inst = self.dataset_inst.processes.get_first()
+
+    # get the number of nlo jets and the di-lepton pt
+    njets = events.LHE.NpNLO
+
+    # raise a warning if a datasets was already created for a specific "bin" (leaf process),
+    # but actually does not fit
+    njets_range = process_inst.x("njets", None)
+    if njets_range is not None:
+        outliers = (njets < njets_range[0]) | (njets >= njets_range[1])
+        if ak.any(outliers):
+            logger.warning(
+                f"dataset {self.dataset_inst.name} is meant to contain njet values in the range "
+                f"[{njets_range[0]}, {njets_range[0]}), but found {ak.sum(outliers)} events "
+                "outside this range",
+            )
+
+    # lookup the id and check for invalid values
+    process_ids = np.squeeze(np.asarray(self.id_table[self.key_func(njets)].todense()))
+    invalid_mask = process_ids == 0
+    if ak.any(invalid_mask):
+        raise ValueError(
+            f"found {sum(invalid_mask)} dy events that could not be assigned to a process",
+        )
+
+    # store them
+    events = set_ak_column_i64(events, "process_id", process_ids)
+
+    return events
+
+
+@process_ids_w.setup
+def process_ids_w_setup(
+    self: Producer,
+    reqs: dict,
+    inputs: dict,
+    reader_targets: InsertableDict,
+) -> None:
+    # define stitching ranges for the DY datasets covered by this producer's dy_inclusive_dataset
+    stitching_ranges: list[NJetsRange] = []
+    for proc in self.w_leaf_processes:
+        logger.warning(f"proc : {proc}")
+        njets = proc.x.njets
+        stitching_ranges.append(njets)
+
+    # sort by the first element of the ptll range
+    sorted_stitching_ranges: list[NJetsRange] = [
+        nj_range for nj_range in sorted(stitching_ranges, key=lambda nj_range: nj_range[0])
+    ]
+
+    # define a key function that maps njets and pt to a unique key for use in a lookup table
+    def key_func(njets):
+        # potentially convert single values into arrays
+        single = False
+        if isinstance(njets, int):
+            njets = np.array([njets], dtype=np.int32)
+            single = True
+
+        # map into bins (index 0 means no binning)
+        nj_bins = np.zeros(len(njets), dtype=np.int32)
+        for nj_bin, nj_range in enumerate(sorted_stitching_ranges, 1):
+            # nj_bin
+            nj_mask = (nj_range[0] <= njets) & (njets < nj_range[1])
+            nj_bins[nj_mask] = nj_bin
+
+        return nj_bins[0] if single else nj_bins
+
+    self.key_func = key_func
+
+    # define the lookup table
+    max_nj_bin = len(sorted_stitching_ranges)
+
+    self.id_table = sp.sparse.lil_matrix((max_nj_bin + 1,1), dtype=np.int64)
+
+    # fill it
+    for proc in self.w_leaf_processes:
+        key = key_func(proc.x.njets[0])
+        self.id_table[key] = proc.id
+    #logger.info(f"id_table : \n{self.id_table}")

--- a/httcp/production/sample_split.py
+++ b/httcp/production/sample_split.py
@@ -11,6 +11,7 @@ coffea = maybe_import("coffea")
 set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
 
 
+
 @producer(
     uses={f"Tau.{var}" for var in [
                 "decayMode", "genPartFlav"
@@ -33,23 +34,30 @@ def split_dy(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         "tau_had"   : 5,
         "fake"      : 6
     }
-    hcand_ele_mu_DM = events.hcand.decayMode[:,0]
+    #hcand_ele_mu_DM = events.hcand.decayMode[:,0]
+    hcand_tau_DM = events.hcand.decayMode[:,1]
+    
     # hcand_Tau_idx = events.hcand.rawIdx[:,1:2]
     # mask_hcand_tau_idx = ak.flatten(hcand_Tau_idx)
     match = events.Tau.genPartFlav
     #### The ak.any() is a nasty fix that need to be removed, we have tautau that needs to be taken into account properly
     mu2tau_fakes_mask = ak.any(((match == tau_part_flav["prompt_mu"]) | (match == tau_part_flav["tau->mu"])),axis=1)
-    e2tau_fakes_mask = ak.any(((match == tau_part_flav["prompt_e"]) | (match == tau_part_flav["tau->e"])),axis=1)
-    genuine_tau_mask = ak.any((match == tau_part_flav["tau_had"]),axis=1)
-
-    unknown_mask = ak.any(((match == tau_part_flav["unknown"]) | (match == tau_part_flav["fake"])),axis=1)
+    e2tau_fakes_mask  = ak.any(((match == tau_part_flav["prompt_e"]) | (match == tau_part_flav["tau->e"])),axis=1)
+    j2tau_fakes_mask  = ak.any(((match == tau_part_flav["unknown"]) | (match == tau_part_flav["fake"])),axis=1)
+    genuine_tau_mask  = ak.any((match == tau_part_flav["tau_had"]),axis=1)
     
-    z_proc_id     = 51100 #self.dataset_inst.processes.values()[0].id
+    z_proc_id       = 51100 #self.dataset_inst.processes.values()[0].id
+
+    # N.B. For tau-tau channel, lets assume the leading tau is true
+    z_j2tau_proc_id = 51097 # if the hcand2 i.e. tauh is from jet or not
+    z_t2tau_proc_id = 51098 # if the hcand2 i.e. tauh is true or not
+    z_l2tau_proc_id = 51099 # if the hcand2 i.e. tauh is from e/mu or not
+
     #ztoee_proc_id = 51101
     #ztomm_proc_id = 51102
-    ztounknown_id = 51097
-    ztott_proc_id = 51098
-    ztoll_proc_id = 51099
+    #ztounknown_id = 51097
+    #ztott_proc_id = 51098
+    #ztoll_proc_id = 51099
     
     #from IPython import embed; embed()
     
@@ -64,14 +72,21 @@ def split_dy(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     #    & genuine_tau_mask
     #)
     
-    process_id = ak.where((mu2tau_fakes_mask | e2tau_fakes_mask), ztoll_proc_id, events.process_id)
-    process_id = ak.where(genuine_tau_mask, ztott_proc_id, process_id)
-    process_id = ak.where(unknown_mask, ztounknown_id, process_id)
-    
-    #process_id = ak.where((mu2tau_fakes_mask & (hcand_ele_mu_DM == -2)), 51001, 51004)
-    #process_id = ak.where((e2tau_fakes_mask & (hcand_ele_mu_DM == -1)), 51003, process_id)
+    #process_id = ak.where((mu2tau_fakes_mask | e2tau_fakes_mask), ztoll_proc_id, events.process_id)
+    #process_id = ak.where(genuine_tau_mask, ztott_proc_id, process_id)
+    #process_id = ak.where(unknown_mask, ztounknown_id, process_id)
+
+    process_id = ak.where((mu2tau_fakes_mask | e2tau_fakes_mask),
+                          z_l2tau_proc_id,
+                          events.process_id)
+    process_id = ak.where(j2tau_fakes_mask,
+                          z_j2tau_proc_id,
+                          process_id)
+    process_id = ak.where(genuine_tau_mask,
+                          z_t2tau_proc_id,
+                          process_id)
+
     events = remove_ak_column(events, "process_id")
     events = set_ak_column(events, "process_id", process_id, value_type=np.int64)
 
     return events
-

--- a/httcp/selection/event_category.py
+++ b/httcp/selection/event_category.py
@@ -98,6 +98,7 @@ def get_categories(
         "is_a1_1pr_2pi0_1", "is_a1_1pr_2pi0_2",
         "is_a1_3pr_0pi0_1", "is_a1_3pr_0pi0_2",
         "is_a1_3pr_1pi0_1", "is_a1_3pr_1pi0_2",
+        "is_ipsig_0to1_1",
     },
     exposed=False,
 )
@@ -201,6 +202,11 @@ def build_abcd_masks(
 
     is_lep_1 = h1.decayMode < 0
     is_lep_1 = ak.fill_none(ak.any(is_lep_1, axis=1), False)
+
+    # IPSig
+    is_ipsig_0to1_1 = h1.IPsig < 1.0
+    is_ipsig_0to1_1 = ak.fill_none(ak.any(is_ipsig_0to1_1, axis=1), False)
+
     
     # h1 to pion
     # only for tautau channel
@@ -273,5 +279,10 @@ def build_abcd_masks(
     events = set_ak_column(events, "is_a1_3pr_1pi0_1",  is_a1_3pr_1pi0_1)
     events = set_ak_column(events, "is_a1_3pr_1pi0_2",  is_a1_3pr_1pi0_2)
 
+    events = set_ak_column(events, "is_ipsig_0to1_1", is_ipsig_0to1_1)
+
+    # channel wise events in several categories for debugging
+    # -- for tautau
+    
     
     return events

--- a/httcp/selection/lepton_pair_mutau.py
+++ b/httcp/selection/lepton_pair_mutau.py
@@ -237,8 +237,8 @@ def mutau_selection(
     vs_jet_wp       = self.config_inst.x.deep_tau_info[tau_tagger].vs_j["mutau"]
     
     is_good_tau     = (
-        (taus.idDeepTau2018v2p5VSjet   >= tau_tagger_wps.vs_j[vs_jet_wp])
-        & (taus.idDeepTau2018v2p5VSe   >= tau_tagger_wps.vs_e[vs_e_wp])
+        #(taus.idDeepTau2018v2p5VSjet   >= tau_tagger_wps.vs_j[vs_jet_wp])
+        (taus.idDeepTau2018v2p5VSe   >= tau_tagger_wps.vs_e[vs_e_wp])
         & (taus.idDeepTau2018v2p5VSmu  >= tau_tagger_wps.vs_m[vs_mu_wp])
     )
 

--- a/httcp/util.py
+++ b/httcp/util.py
@@ -72,15 +72,41 @@ def IF_DATASET_HAS_LHE_WEIGHTS(
     return None if func.dataset_inst.has_tag("no_lhe_weights") else self.get()
 
 @deferred_column
-def IF_DATASET_IS_DY_LO(
+def IF_DATASET_IS_DY(
     self: ArrayFunction.DeferredColumn,
     func: ArrayFunction,
 ) -> Any | set[Any]:
     if getattr(func, "dataset_inst", None) is None:
         return self.get()
+    return None if not func.dataset_inst.has_tag("is_dy") else self.get()
 
-    return None if not func.dataset_inst.has_tag("is_dy_LO") else self.get()
+@deferred_column
+def IF_DATASET_IS_W(
+    self: ArrayFunction.DeferredColumn,
+    func: ArrayFunction,
+) -> Any | set[Any]:
+    if getattr(func, "dataset_inst", None) is None:
+        return self.get()
+    return None if not func.dataset_inst.has_tag("is_w") else self.get()
 
+@deferred_column
+def IF_DATASET_IS_SIGNAL(
+    self: ArrayFunction.DeferredColumn,
+    func: ArrayFunction,
+) -> Any | set[Any]:
+    if getattr(func, "dataset_inst", None) is None:
+        return self.get()
+    return None if not (func.dataset_inst.has_tag("is_ggf_signal") | func.dataset_inst.has_tag("is_vh_signal")) else self.get()
+
+@deferred_column
+def IF_ALLOW_STITCHING(
+        self: ArrayFunction.DeferredColumn,
+        func: ArrayFunction,
+) -> Any | set[Any]:
+    if getattr(func, "dataset_inst", None) is None:
+        return self.get()
+    return None if not (func.dataset_inst.has_tag("is_w") | func.dataset_inst.has_tag("is_dy")) else self.get()
+    
 
 def transverse_mass(lepton: ak.Array, met: ak.Array) -> ak.Array:
     dphi_lep_met = lepton.delta_phi(met)

--- a/httcp/weight/main.py
+++ b/httcp/weight/main.py
@@ -57,7 +57,15 @@ def main_init(self: WeightProducer) -> None:
                 for shift_inst in self.config_inst.x.event_weights[weight_name]
             )
             if is_zpt_reweight:
-                if not self.dataset_inst.has_tag("is_dy_LO"):
+                if not self.dataset_inst.has_tag("is_dy"):
+                    continue
+
+            is_tauspinner_weight = any(
+                shift_inst.has_tag("tauspinner_weight")
+                for shift_inst in self.config_inst.x.event_weights[weight_name] 
+            )
+            if is_tauspinner_weight:
+                if not (self.dataset_inst.has_tag("is_ggf_signal") | self.dataset_inst.has_tag("is_vh_signal")):
                     continue
 
         self.weight_columns.append(weight_name)

--- a/yamls/2022PreEE_full.yml
+++ b/yamls/2022PreEE_full.yml
@@ -6,12 +6,13 @@ postfix : PreEE
 wrapper : true
 limited : false
 workers : 3
+tasks_per_job  : 3
 
 args:
   config    : run3_2022_preEE_nano_cp_tau_v12
   workflow  : htcondor
   branch    : -1
-  version   : dummy
+  version   : Run3_2022PreEE_full_20241027_020905
 
   datasets  :
     ## == data ==
@@ -50,14 +51,15 @@ args:
   processes :
     - data
     - w_lnu
-    - dy_lep_m10to50
-    - dy_lep_m50
+    - dy_m10to50
+    - dy_m50toinf_lep
+    - dy_m50toinf_tau
     - tt
     #- st_tchannel
     #- st_twchannel
     - st
     - vv
-    - h_ggf_tautau
+    - h_ggf_htt
 
   categories:
     #- incl
@@ -154,5 +156,18 @@ args:
     #- PhiCP_IPDP_alpha_lt_piby4
     #- PhiCP_IPDP_alpha_gt_piby4
 
+  shifts:
+    #- minbias_xs
+    #- tau
+    #- e
+    #- e_trig
+    #- e_xtrig
+    #- mu_id
+    #- mu_iso
+    #- mu_trig
+    #- mu_xtrig
+    #- zpt
+    
+
   extras:
-    - process-settings "h_ggf_tautau,unstack,500000"
+    - process-settings "h_ggf_htt,unstack,100000"


### PR DESCRIPTION
This PR includes
 - MC Stitching for DY (both nJet and pt binned) and WJets (jet binned only) samples
 - JEC, JER and Type-1 MET corrections
   - TODO: Propagate TEC to MET
 - Re-implement tau spinner weight as v2 nanoaods have all the spinner weights
 - new categories for different nJets and different IPsig values
 - adding new variables 

Special mention:
 - Using both `increment_stats` and `custom_stats` to save initial `nEvents_per_process` to get the fraction, which is multiplied to the total nEvents from campaign for stitching purpose. This needs to be checked thoroughly 